### PR TITLE
map file foreign keys to supp file list in review assignments

### DIFF
--- a/journal_transporter/transfer/transfer_handler.py
+++ b/journal_transporter/transfer/transfer_handler.py
@@ -147,6 +147,7 @@ class TransferHandler:
                                         "reviewer": "users",
                                         "review_files": "files",
                                         "reviewer_file": "files",
+                                        "supp_files": "files",
                                         "review_form": "review_forms"
                                     },
                                     "children": {


### PR DESCRIPTION
- Add supp_files field from review assignments to the foreign key map so we get janeway IDs to import with